### PR TITLE
BASHI-18: Fix pull request link generation in release notes.

### DIFF
--- a/.github/config/release-drafter.yml
+++ b/.github/config/release-drafter.yml
@@ -17,7 +17,7 @@ categories:
       - "technical"
 exclude-labels:
   - "exclude"
-change-template: "- $TITLE (@$AUTHOR | PR#$NUMBER)"
+change-template: "- $TITLE (@$AUTHOR | PR #$NUMBER)"
 template: |
   ## Changes
 

--- a/.github/config/release-drafter.yml
+++ b/.github/config/release-drafter.yml
@@ -19,6 +19,6 @@ exclude-labels:
   - "exclude"
 change-template: "- $TITLE (@$AUTHOR | PR #$NUMBER)"
 template: |
-  ## Changes
+  # Changes
 
   $CHANGES


### PR DESCRIPTION
No space prior to the `#` causes GitHub to fail to link the associated PR automatically.