### PR TITLE
BASHI-109: [Breaking] Assorted Utilities & Remove Implicit Type Cast of TinyTypes.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,9 +33,7 @@ jobs:
 
       - name: "[Build] Build Solution"
         run: |
-          dotnet build \
-            --no-restore \
-            --configuration Release \
+          dotnet build --no-restore --configuration Release \
             /p:VersionPrefix=$GitVersion_MajorMinorPatch \
             /p:VersionSuffix=$GitVersion_PreReleaseLabel \
             /p:AssemblyVersion=$GitVersion_AssemblySemVer \
@@ -45,18 +43,15 @@ jobs:
             /p:RepositoryCommit=$GITHUB_SHA
 
       - name: "[Test] Run Tests"
-        run: |
-          dotnet test \
-            --configuration Release \
-            --no-build \
-            test/Bashi.Core.Tests/Bashi.Core.Tests.csproj
+        run: dotnet test --no-build --configuration Release
 
       - name: "[Deploy] Create NuGet Package"
         id: dotnet-pack
         run: |
           dotnet pack \
-            --configuration Release \
+            --no-restore \
             --no-build \
+            --configuration Release \
             /p:VersionPrefix=$GitVersion_MajorMinorPatch \
             /p:VersionSuffix=$GitVersion_PreReleaseLabel \
             /p:AssemblyVersion=$GitVersion_AssemblySemVer \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
           git branch --create-reflog master origin/master
 
       - name: "[Setup] Create GitVersion"
-        uses: docker://gittools/gitversion:5.5.2-linux-alpine.3.10-x64-netcoreapp3.1
+        uses: docker://gittools/gitversion:5.6.1-alpine.3.12-x64-3.1
         with:
           args: /github/workspace /nofetch /output buildserver
 

--- a/src/Bashi.Core/Extensions/EnumerableExtensions.cs
+++ b/src/Bashi.Core/Extensions/EnumerableExtensions.cs
@@ -1,10 +1,32 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 
 namespace Bashi.Core.Extensions
 {
     public static class EnumerableExtensions
     {
+        private static readonly Random Random = new();
+
+        /// <summary>
+        /// Returns the <paramref name="source"/> enumerable as a <see cref="IReadOnlyList{T}"/>.
+        /// If it is already an instance of an <see cref="IReadOnlyList{T}"/>, then it will be returned as is.
+        /// Otherwise it will be materialized to a new <see cref="IReadOnlyList{T}"/>.
+        /// </summary>
+        /// <param name="source">The enumerable to be turned into a <see cref="IReadOnlyList{T}"/>.</param>
+        /// <typeparam name="T">The type of the elements of <paramref name="source"/>.</typeparam>
+        /// <returns>The <paramref name="source"/> enumerable if already readonly, otherwise it will be wrapped as read-only.</returns>
+        public static IReadOnlyList<T> AsReadOnlyList<T>(this IEnumerable<T> source)
+        {
+            return source switch
+            {
+                IList<T> { IsReadOnly: false } list => new ReadOnlyCollection<T>(list),
+                IReadOnlyList<T> readOnlyList => readOnlyList,
+                _ => source.ToList().AsReadOnly()
+            };
+        }
+
         /// <summary>
         /// Returns the <paramref name="source"/> enumerable unchanged or an empty enumerable if <paramref name="source"/> is null.
         /// </summary>
@@ -14,6 +36,18 @@ namespace Bashi.Core.Extensions
         public static IEnumerable<T> NullToEmpty<T>(this IEnumerable<T>? source)
         {
             return source ?? Enumerable.Empty<T>();
+        }
+
+        /// <summary>
+        /// Returns a random entry from the <paramref name="source"/> enumerable.
+        /// </summary>
+        /// <param name="source">The enumerable to select from.</param>
+        /// <typeparam name="T">The type of the elements of <paramref name="source"/>.</typeparam>
+        /// <returns>An instance of <typeparamref name="T"/> from the <paramref name="source"/> enumerable.</returns>
+        public static T? FirstRandom<T>(this IEnumerable<T> source)
+        {
+            var list = source.ToList();
+            return list.Count == 0 ? default : list[EnumerableExtensions.Random.Next(0, list.Count)];
         }
     }
 }

--- a/src/Bashi.Core/TinyTypes/TinyType.cs
+++ b/src/Bashi.Core/TinyTypes/TinyType.cs
@@ -139,5 +139,11 @@ namespace Bashi.Core.TinyTypes
         {
             return EqualityComparer<T>.Default.Equals(this.Value, other);
         }
+
+        /// <inheritdoc />
+        public override string ToString()
+        {
+            return this.Value.ToString()!;
+        }
     }
 }

--- a/src/Bashi.Core/TinyTypes/TinyType.cs
+++ b/src/Bashi.Core/TinyTypes/TinyType.cs
@@ -34,14 +34,6 @@ namespace Bashi.Core.TinyTypes
         public T Value { get; }
 
         /// <summary>
-        /// Implicitly casts a <see cref="TinyType{T}"/> into the underlying <typeparamref name="T"/>.
-        /// </summary>
-        /// <param name="arg">The instance of the TinyType.</param>
-        /// <returns>Returns <see cref="Value"/>.</returns>
-        [SuppressMessage("ReSharper", "CA2225", Justification = "Operator is a shorthand for accessing the Value property.")]
-        public static implicit operator T(TinyType<T> arg) => arg.Value;
-
-        /// <summary>
         /// Overriding operator for equality check between two <see cref="TinyType{T}"/> instances.
         /// </summary>
         /// <param name="left">First instance to be compared.</param>

--- a/test/Bashi.Core.Tests/Bashi.Core.Tests.csproj
+++ b/test/Bashi.Core.Tests/Bashi.Core.Tests.csproj
@@ -18,12 +18,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bashi.Tests.Framework" Version="1.1.0" />
-    <PackageReference Include="coverlet.msbuild" Version="2.9.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-    <PackageReference Include="NunitXml.TestLogger" Version="2.1.80" />
+    <PackageReference Include="Bashi.Tests.Framework" Version="2.0.0" />
+    <PackageReference Include="coverlet.msbuild" Version="3.0.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
+    <PackageReference Include="NunitXml.TestLogger" Version="3.0.107" />
   </ItemGroup>
 
 </Project>

--- a/test/Bashi.Core.Tests/Extensions/EnumExtensionsTests.cs
+++ b/test/Bashi.Core.Tests/Extensions/EnumExtensionsTests.cs
@@ -7,18 +7,21 @@ namespace Bashi.Core.Tests.Extensions
     [TestFixture]
     public class EnumExtensionsTests
     {
-        [Test]
-        public void GetDescription_GivenMemberDoesNotHaveDescriptionAttribute_ShouldReturnToString()
+        public class GetDescriptionTests
         {
-            Assert.That(EnumUtilTests.TestColour.Yellow.GetDescription(), Is.EqualTo("Yellow"));
-        }
+            [Test]
+            public void GetDescription_GivenMemberDoesNotHaveDescriptionAttribute_ShouldReturnToString()
+            {
+                Assert.That(EnumUtilTests.TestColour.Yellow.GetDescription(), Is.EqualTo("Yellow"));
+            }
 
-        [Test]
-        public void GetDescription_GivenMemberDoesHaveDescriptionAttribute_ShouldReturnDescriptionValue()
-        {
-            Assert.That(EnumUtilTests.TestColour.Red.GetDescription(), Is.EqualTo("#FF0000"));
-            Assert.That(EnumUtilTests.TestColour.Green.GetDescription(), Is.EqualTo("#00FF00"));
-            Assert.That(EnumUtilTests.TestColour.Blue.GetDescription(), Is.EqualTo("#0000FF"));
+            [Test]
+            public void GetDescription_GivenMemberDoesHaveDescriptionAttribute_ShouldReturnDescriptionValue()
+            {
+                Assert.That(EnumUtilTests.TestColour.Red.GetDescription(), Is.EqualTo("#FF0000"));
+                Assert.That(EnumUtilTests.TestColour.Green.GetDescription(), Is.EqualTo("#00FF00"));
+                Assert.That(EnumUtilTests.TestColour.Blue.GetDescription(), Is.EqualTo("#0000FF"));
+            }
         }
     }
 }

--- a/test/Bashi.Core.Tests/Extensions/EnumExtensionsTests.cs
+++ b/test/Bashi.Core.Tests/Extensions/EnumExtensionsTests.cs
@@ -10,13 +10,13 @@ namespace Bashi.Core.Tests.Extensions
         public class GetDescriptionTests
         {
             [Test]
-            public void GetDescription_GivenMemberDoesNotHaveDescriptionAttribute_ShouldReturnToString()
+            public void GivenMemberDoesNotHaveDescriptionAttribute_ShouldReturnToString()
             {
                 Assert.That(EnumUtilTests.TestColour.Yellow.GetDescription(), Is.EqualTo("Yellow"));
             }
 
             [Test]
-            public void GetDescription_GivenMemberDoesHaveDescriptionAttribute_ShouldReturnDescriptionValue()
+            public void GivenMemberDoesHaveDescriptionAttribute_ShouldReturnDescriptionValue()
             {
                 Assert.That(EnumUtilTests.TestColour.Red.GetDescription(), Is.EqualTo("#FF0000"));
                 Assert.That(EnumUtilTests.TestColour.Green.GetDescription(), Is.EqualTo("#00FF00"));

--- a/test/Bashi.Core.Tests/Extensions/EnumerableExtensionsTests.cs
+++ b/test/Bashi.Core.Tests/Extensions/EnumerableExtensionsTests.cs
@@ -8,20 +8,67 @@ namespace Bashi.Core.Tests.Extensions
     [TestFixture]
     public class EnumerableExtensionsTests
     {
-        [Test]
-        public void NullToEmpty_GivenNull_ThenReturnsEmpty()
+        public class AsReadOnlyListTests
         {
-            IEnumerable<string>? source = null;
-            Assert.That(source.NullToEmpty(), Is.Not.Null);
+            [Test]
+            public void GivenEnumerable_ThenReturnsNewList()
+            {
+                var enumerable = Enumerable.Range(1, 10);
+                Assert.That(enumerable.AsReadOnlyList(), Is.Not.SameAs(enumerable));
+            }
+
+            [Test]
+            public void GivenList_ThenReturnsNewList()
+            {
+                var list = Enumerable.Range(1, 10).ToList();
+                Assert.That(list.AsReadOnlyList(), Is.Not.SameAs(list));
+            }
+
+            [Test]
+            public void GivenReadOnlyList_ThenReturnsExistingList()
+            {
+                var readonlyList = Enumerable.Range(1, 10).ToList().AsReadOnly();
+                Assert.That(readonlyList.AsReadOnlyList(), Is.SameAs(readonlyList));
+            }
         }
 
-        [Test]
-        public void NullToEmpty_GivenNonNull_ThenReturnsSameInstance()
+        public class NullToEmptyTests
         {
-            IEnumerable<string> source = Enumerable.Empty<string>();
-            IEnumerable<int> source2 = Enumerable.Range(0, 5);
-            Assert.That(source.NullToEmpty(), Is.EqualTo(source));
-            Assert.That(source2.NullToEmpty(), Is.EqualTo(source2));
+            [Test]
+            public void GivenNull_ThenReturnsEmpty()
+            {
+                IEnumerable<string>? source = null;
+                Assert.That(source.NullToEmpty(), Is.Not.Null);
+            }
+
+            [Test]
+            public void GivenNonNull_ThenReturnsSameInstance()
+            {
+                IEnumerable<string> source = Enumerable.Empty<string>();
+                IEnumerable<int> source2 = Enumerable.Range(0, 5);
+                Assert.That(source.NullToEmpty(), Is.SameAs(source));
+                Assert.That(source2.NullToEmpty(), Is.SameAs(source2));
+            }
+        }
+
+        public class FirstRandomTests
+        {
+            [Test]
+            public void GivenEmptyList_ThenReturnsDefault()
+            {
+                var empty = Enumerable.Empty<int>();
+                Assert.That(empty.FirstRandom(), Is.EqualTo(0));
+            }
+
+            [Test]
+            public void GivenListOf10Items_ThenReturnsAnItemFromCollectionEachTime()
+            {
+                var list = Enumerable.Range(1, 10).ToList();
+                for (var i = 0; i < 100; i++)
+                {
+                    Assert.That(list, Contains.Item(list.FirstRandom()));
+                }
+            }
         }
     }
 }

--- a/test/Bashi.Core.Tests/TinyTypes/TinyStringTests.cs
+++ b/test/Bashi.Core.Tests/TinyTypes/TinyStringTests.cs
@@ -9,62 +9,6 @@ namespace Bashi.Core.Tests.TinyTypes
     [TestFixture]
     public class TinyStringTests
     {
-        [Test]
-        public void CompareTo_GivenNull_ThenShouldThrowException()
-        {
-            var tt = new MyTinyString(TestData.WellKnownString);
-            Assert.That(() => tt.CompareTo((object?)null), Throws.ArgumentNullException);
-            Assert.That(() => tt.CompareTo((MyTinyString?)null), Throws.ArgumentNullException);
-        }
-
-        [Test]
-        public void Equals_GivenStringsWithDifferentCases_WhenStringComparerIgnoresCase_ThenShouldBeTrue()
-        {
-            var tt = new MyTinyString(TestData.WellKnownString);
-            var upperTt = new MyTinyString(TestData.WellKnownString.ToUpper(CultureInfo.InvariantCulture));
-            Assert.That(tt.Equals(upperTt), Is.True);
-        }
-
-        [Test]
-        public void GetHashCode_GivenStringsWithDifferentCases_WhenStringComparerIgnoresCase_ThenShouldBeTrue()
-        {
-            var tt = new MyTinyString(TestData.WellKnownString);
-            var upperTt = new MyTinyString(TestData.WellKnownString.ToUpper(CultureInfo.InvariantCulture));
-            Assert.That(tt.GetHashCode(), Is.EqualTo(upperTt.GetHashCode()));
-        }
-
-        [Test]
-        public void CompareTo_GivenStringWithDifferentCases_WhenStringComparerIgnoresCase_ThenShouldBeZero()
-        {
-            var tt = new MyTinyString(TestData.WellKnownString);
-            var upperTt = new MyTinyString(TestData.WellKnownString.ToUpper(CultureInfo.InvariantCulture));
-            Assert.That(tt.CompareTo(upperTt), Is.Zero);
-        }
-
-        [Test]
-        public void Equals_GivenStringsWithDifferentCases_WhenStringComparerIsCaseSensitive_ThenShouldBeFalse()
-        {
-            var tt = new MySensitiveTinyString(TestData.WellKnownString);
-            var upperTt = new MySensitiveTinyString(TestData.WellKnownString.ToUpper(CultureInfo.InvariantCulture));
-            Assert.That(tt.Equals(upperTt), Is.False);
-        }
-
-        [Test]
-        public void GetHashCode_GivenStringsWithDifferentCases_WhenStringComparerIsCaseSensitive_ThenShouldBeFalse()
-        {
-            var tt = new MySensitiveTinyString(TestData.WellKnownString);
-            var upperTt = new MySensitiveTinyString(TestData.WellKnownString.ToUpper(CultureInfo.InvariantCulture));
-            Assert.That(tt.GetHashCode(), Is.Not.EqualTo(upperTt.GetHashCode()));
-        }
-
-        [Test]
-        public void CompareTo_GivenStringWithDifferentCases_WhenStringComparerIsCaseSensitive_ThenShouldBeZero()
-        {
-            var tt = new MySensitiveTinyString(TestData.WellKnownString);
-            var upperTt = new MySensitiveTinyString(TestData.WellKnownString.ToUpper(CultureInfo.InvariantCulture));
-            Assert.That(tt.CompareTo(upperTt), Is.Not.Zero);
-        }
-
         private class MyTinyString : TinyString
         {
             public MyTinyString(string value)
@@ -78,6 +22,71 @@ namespace Bashi.Core.Tests.TinyTypes
             public MySensitiveTinyString(string value)
                 : base(value, StringComparer.Ordinal)
             {
+            }
+        }
+
+        public class CompareToTests
+        {
+            [Test]
+            public void GivenNull_ThenShouldThrowException()
+            {
+                var tt = new MyTinyString(TestData.WellKnownString);
+                Assert.That(() => tt.CompareTo((object?)null), Throws.ArgumentNullException);
+                Assert.That(() => tt.CompareTo((MyTinyString?)null), Throws.ArgumentNullException);
+            }
+
+            [Test]
+            public void GivenStringWithDifferentCases_WhenStringComparerIgnoresCase_ThenShouldBeZero()
+            {
+                var tt = new MyTinyString(TestData.WellKnownString);
+                var upperTt = new MyTinyString(TestData.WellKnownString.ToUpper(CultureInfo.InvariantCulture));
+                Assert.That(tt.CompareTo(upperTt), Is.Zero);
+            }
+
+            [Test]
+            public void GivenStringWithDifferentCases_WhenStringComparerIsCaseSensitive_ThenShouldBeZero()
+            {
+                var tt = new MySensitiveTinyString(TestData.WellKnownString);
+                var upperTt = new MySensitiveTinyString(TestData.WellKnownString.ToUpper(CultureInfo.InvariantCulture));
+                Assert.That(tt.CompareTo(upperTt), Is.Not.Zero);
+            }
+        }
+
+        public class EqualsTests
+        {
+            [Test]
+            public void GivenStringsWithDifferentCases_WhenStringComparerIgnoresCase_ThenShouldBeTrue()
+            {
+                var tt = new MyTinyString(TestData.WellKnownString);
+                var upperTt = new MyTinyString(TestData.WellKnownString.ToUpper(CultureInfo.InvariantCulture));
+                Assert.That(tt.Equals(upperTt), Is.True);
+            }
+
+            [Test]
+            public void GivenStringsWithDifferentCases_WhenStringComparerIsCaseSensitive_ThenShouldBeFalse()
+            {
+                var tt = new MySensitiveTinyString(TestData.WellKnownString);
+                var upperTt = new MySensitiveTinyString(TestData.WellKnownString.ToUpper(CultureInfo.InvariantCulture));
+                Assert.That(tt.Equals(upperTt), Is.False);
+            }
+        }
+
+        public class GetHashCodeTests
+        {
+            [Test]
+            public void GivenStringsWithDifferentCases_WhenStringComparerIgnoresCase_ThenShouldBeTrue()
+            {
+                var tt = new MyTinyString(TestData.WellKnownString);
+                var upperTt = new MyTinyString(TestData.WellKnownString.ToUpper(CultureInfo.InvariantCulture));
+                Assert.That(tt.GetHashCode(), Is.EqualTo(upperTt.GetHashCode()));
+            }
+
+            [Test]
+            public void GivenStringsWithDifferentCases_WhenStringComparerIsCaseSensitive_ThenShouldBeFalse()
+            {
+                var tt = new MySensitiveTinyString(TestData.WellKnownString);
+                var upperTt = new MySensitiveTinyString(TestData.WellKnownString.ToUpper(CultureInfo.InvariantCulture));
+                Assert.That(tt.GetHashCode(), Is.Not.EqualTo(upperTt.GetHashCode()));
             }
         }
     }

--- a/test/Bashi.Core.Tests/TinyTypes/TinyTypeTests.cs
+++ b/test/Bashi.Core.Tests/TinyTypes/TinyTypeTests.cs
@@ -21,7 +21,7 @@ namespace Bashi.Core.Tests.TinyTypes
         public class CompareToTests
         {
             [Test]
-            public void CompareTo_GivenNullOrNonMatchingTypes_ThenWillThrowException()
+            public void GivenNullOrNonMatchingTypes_ThenWillThrowException()
             {
                 var tt = new MyNumber(TestData.WellKnownInt);
 
@@ -32,7 +32,7 @@ namespace Bashi.Core.Tests.TinyTypes
             }
 
             [Test]
-            public void CompareTo_GivenMatchingTypes_ThenWillCompareByUnderlying()
+            public void GivenMatchingTypes_ThenWillCompareByUnderlying()
             {
                 var tt = new MyNumber(TestData.WellKnownInt);
                 var value = TestData.NextInt();
@@ -47,7 +47,7 @@ namespace Bashi.Core.Tests.TinyTypes
         public class EqualsTests
         {
             [Test]
-            public void Equals_GivenANonMatchingTypeAndValue_ThenTheyAreNotEqual()
+            public void GivenANonMatchingTypeAndValue_ThenTheyAreNotEqual()
             {
                 var tt = new MyNumber(TestData.WellKnownInt);
 
@@ -57,7 +57,7 @@ namespace Bashi.Core.Tests.TinyTypes
             }
 
             [Test]
-            public void Equals_GivenAMatchingType_WhenValuesDoNotMatch_ThenTheyAreNotEqual()
+            public void GivenAMatchingType_WhenValuesDoNotMatch_ThenTheyAreNotEqual()
             {
                 var tt = new MyNumber(TestData.WellKnownInt);
 
@@ -69,7 +69,7 @@ namespace Bashi.Core.Tests.TinyTypes
             }
 
             [Test]
-            public void Equals_GivenAMatchingType_WhenValuesDoNotMatch_ThenTheyAreEqual()
+            public void GivenAMatchingType_WhenValuesDoNotMatch_ThenTheyAreEqual()
             {
                 var tt = new MyNumber(TestData.WellKnownInt);
 
@@ -84,7 +84,7 @@ namespace Bashi.Core.Tests.TinyTypes
         public class GetHashCodeTests
         {
             [Test]
-            public void GetHashCode_MatchesUnderlyingValueHashCode()
+            public void MatchesUnderlyingValueHashCode()
             {
                 var tt = new MyNumber(TestData.WellKnownInt);
                 Assert.That(tt.GetHashCode(), Is.EqualTo(TestData.WellKnownInt.GetHashCode()));
@@ -94,7 +94,7 @@ namespace Bashi.Core.Tests.TinyTypes
         public class OperationTests
         {
             [Test]
-            public void ImplicitOperatorToUnderlying_ShouldAutomaticallyConvertValues()
+            public void ShouldAutomaticallyConvertValues()
             {
                 var tt = new MyNumber(TestData.WellKnownInt);
                 int value = tt;

--- a/test/Bashi.Core.Tests/TinyTypes/TinyTypeTests.cs
+++ b/test/Bashi.Core.Tests/TinyTypes/TinyTypeTests.cs
@@ -90,17 +90,5 @@ namespace Bashi.Core.Tests.TinyTypes
                 Assert.That(tt.GetHashCode(), Is.EqualTo(TestData.WellKnownInt.GetHashCode()));
             }
         }
-
-        public class OperationTests
-        {
-            [Test]
-            public void ShouldAutomaticallyConvertValues()
-            {
-                var tt = new MyNumber(TestData.WellKnownInt);
-                int value = tt;
-                Assert.That(tt.Value, Is.EqualTo(value));
-                Assert.That(value, Is.EqualTo(TestData.WellKnownInt));
-            }
-        }
     }
 }

--- a/test/Bashi.Core.Tests/TinyTypes/TinyTypeTests.cs
+++ b/test/Bashi.Core.Tests/TinyTypes/TinyTypeTests.cs
@@ -10,84 +10,96 @@ namespace Bashi.Core.Tests.TinyTypes
     [SuppressMessage("ReSharper", "RedundantCast", Justification = "Verifying specific equalities")]
     public class TinyTypeTests
     {
-        [Test]
-        public void ImplicitOperatorToUnderlying_ShouldAutomaticallyConvertValues()
-        {
-            var tt = new MyNumber(TestData.WellKnownInt);
-            int value = tt;
-            Assert.That(tt.Value, Is.EqualTo(value));
-            Assert.That(value, Is.EqualTo(TestData.WellKnownInt));
-        }
-
-        [Test]
-        public void Equals_GivenANonMatchingTypeAndValue_ThenTheyAreNotEqual()
-        {
-            var tt = new MyNumber(TestData.WellKnownInt);
-
-            Assert.That(tt.Equals(TestData.WellKnownInt), Is.False);
-            Assert.That(tt.Equals((double)TestData.WellKnownInt), Is.False);
-            Assert.That(tt.Equals((object?)null), Is.False);
-        }
-
-        [Test]
-        public void Equals_GivenAMatchingType_WhenValuesDoNotMatch_ThenTheyAreNotEqual()
-        {
-            var tt = new MyNumber(TestData.WellKnownInt);
-
-            var differentInt = TestData.NextInt();
-            Assert.That(tt.Equals(new MyNumber(differentInt)), Is.False);
-            Assert.That(tt == new MyNumber(differentInt), Is.False);
-            Assert.That(tt != new MyNumber(differentInt), Is.True);
-            Assert.That(tt.Equals((MyNumber?)null), Is.False);
-        }
-
-        [Test]
-        public void Equals_GivenAMatchingType_WhenValuesDoNotMatch_ThenTheyAreEqual()
-        {
-            var tt = new MyNumber(TestData.WellKnownInt);
-
-            Assert.That(tt.Equals(tt), Is.True);
-            Assert.That(tt.Equals((object)tt), Is.True);
-            Assert.That(tt.Equals(new MyNumber(TestData.WellKnownInt)), Is.True);
-            Assert.That(tt.Equals(new MyNumber(TestData.WellKnownInt) as object), Is.True);
-            Assert.That(tt == new MyNumber(TestData.WellKnownInt), Is.True);
-        }
-
-        [Test]
-        public void GetHashCode_MatchesUnderlyingValueHashCode()
-        {
-            var tt = new MyNumber(TestData.WellKnownInt);
-            Assert.That(tt.GetHashCode(), Is.EqualTo(TestData.WellKnownInt.GetHashCode()));
-        }
-
-        [Test]
-        public void CompareTo_GivenNullOrNonMatchingTypes_ThenWillThrowException()
-        {
-            var tt = new MyNumber(TestData.WellKnownInt);
-
-            Assert.That(() => tt.CompareTo((object?)null), Throws.ArgumentNullException);
-            Assert.That(() => tt.CompareTo((MyNumber?)null), Throws.ArgumentNullException);
-            Assert.That(() => tt.CompareTo(TestData.WellKnownInt), Throws.ArgumentException);
-            Assert.That(() => tt.CompareTo(TestData.WellKnownString), Throws.ArgumentException);
-        }
-
-        [Test]
-        public void CompareTo_GivenMatchingTypes_ThenWillCompareByUnderlying()
-        {
-            var tt = new MyNumber(TestData.WellKnownInt);
-            var value = TestData.NextInt();
-
-            Assert.That(tt.CompareTo(new MyNumber(value)), Is.EqualTo(TestData.WellKnownInt.CompareTo(value)));
-            Assert.That(tt.CompareTo(new MyNumber(TestData.WellKnownInt)), Is.Zero);
-            Assert.That(tt.CompareTo((object)tt), Is.Zero);
-            Assert.That(tt.CompareTo(tt), Is.Zero);
-        }
-
         private class MyNumber : TinyType<int>
         {
             public MyNumber(int value)
                 : base(value)
             {
+            }
+        }
+
+        public class CompareToTests
+        {
+            [Test]
+            public void CompareTo_GivenNullOrNonMatchingTypes_ThenWillThrowException()
+            {
+                var tt = new MyNumber(TestData.WellKnownInt);
+
+                Assert.That(() => tt.CompareTo((object?)null), Throws.ArgumentNullException);
+                Assert.That(() => tt.CompareTo((MyNumber?)null), Throws.ArgumentNullException);
+                Assert.That(() => tt.CompareTo(TestData.WellKnownInt), Throws.ArgumentException);
+                Assert.That(() => tt.CompareTo(TestData.WellKnownString), Throws.ArgumentException);
+            }
+
+            [Test]
+            public void CompareTo_GivenMatchingTypes_ThenWillCompareByUnderlying()
+            {
+                var tt = new MyNumber(TestData.WellKnownInt);
+                var value = TestData.NextInt();
+
+                Assert.That(tt.CompareTo(new MyNumber(value)), Is.EqualTo(TestData.WellKnownInt.CompareTo(value)));
+                Assert.That(tt.CompareTo(new MyNumber(TestData.WellKnownInt)), Is.Zero);
+                Assert.That(tt.CompareTo((object)tt), Is.Zero);
+                Assert.That(tt.CompareTo(tt), Is.Zero);
+            }
+        }
+
+        public class EqualsTests
+        {
+            [Test]
+            public void Equals_GivenANonMatchingTypeAndValue_ThenTheyAreNotEqual()
+            {
+                var tt = new MyNumber(TestData.WellKnownInt);
+
+                Assert.That(tt.Equals(TestData.WellKnownInt), Is.False);
+                Assert.That(tt.Equals((double)TestData.WellKnownInt), Is.False);
+                Assert.That(tt.Equals((object?)null), Is.False);
+            }
+
+            [Test]
+            public void Equals_GivenAMatchingType_WhenValuesDoNotMatch_ThenTheyAreNotEqual()
+            {
+                var tt = new MyNumber(TestData.WellKnownInt);
+
+                var differentInt = TestData.NextInt();
+                Assert.That(tt.Equals(new MyNumber(differentInt)), Is.False);
+                Assert.That(tt == new MyNumber(differentInt), Is.False);
+                Assert.That(tt != new MyNumber(differentInt), Is.True);
+                Assert.That(tt.Equals((MyNumber?)null), Is.False);
+            }
+
+            [Test]
+            public void Equals_GivenAMatchingType_WhenValuesDoNotMatch_ThenTheyAreEqual()
+            {
+                var tt = new MyNumber(TestData.WellKnownInt);
+
+                Assert.That(tt.Equals(tt), Is.True);
+                Assert.That(tt.Equals((object)tt), Is.True);
+                Assert.That(tt.Equals(new MyNumber(TestData.WellKnownInt)), Is.True);
+                Assert.That(tt.Equals(new MyNumber(TestData.WellKnownInt) as object), Is.True);
+                Assert.That(tt == new MyNumber(TestData.WellKnownInt), Is.True);
+            }
+        }
+
+        public class GetHashCodeTests
+        {
+            [Test]
+            public void GetHashCode_MatchesUnderlyingValueHashCode()
+            {
+                var tt = new MyNumber(TestData.WellKnownInt);
+                Assert.That(tt.GetHashCode(), Is.EqualTo(TestData.WellKnownInt.GetHashCode()));
+            }
+        }
+
+        public class OperationTests
+        {
+            [Test]
+            public void ImplicitOperatorToUnderlying_ShouldAutomaticallyConvertValues()
+            {
+                var tt = new MyNumber(TestData.WellKnownInt);
+                int value = tt;
+                Assert.That(tt.Value, Is.EqualTo(value));
+                Assert.That(value, Is.EqualTo(TestData.WellKnownInt));
             }
         }
     }

--- a/test/Bashi.Core.Tests/TinyTypes/TinyTypeTests.cs
+++ b/test/Bashi.Core.Tests/TinyTypes/TinyTypeTests.cs
@@ -90,5 +90,15 @@ namespace Bashi.Core.Tests.TinyTypes
                 Assert.That(tt.GetHashCode(), Is.EqualTo(TestData.WellKnownInt.GetHashCode()));
             }
         }
+
+        public class ToStringTests
+        {
+            [Test]
+            public void MatchesUnderlyingValueToString()
+            {
+                var tt = new MyNumber(TestData.WellKnownInt);
+                Assert.That(tt.ToString(), Is.EqualTo(TestData.WellKnownInt.ToString()));
+            }
+        }
     }
 }

--- a/test/Bashi.Core.Tests/Utils/EnumUtilTests.cs
+++ b/test/Bashi.Core.Tests/Utils/EnumUtilTests.cs
@@ -17,43 +17,50 @@ namespace Bashi.Core.Tests.Utils
             Yellow
         }
 
-        [Test]
-        public void GetValues_ShouldReturnAllEnumMembers()
+        public class GetValuesTests
         {
-            var expected = new List<TestColour>
+            [Test]
+            public void ShouldReturnAllEnumMembers()
             {
-                TestColour.Red,
-                TestColour.Green,
-                TestColour.Blue,
-                TestColour.Yellow
-            };
-            Assert.That(EnumUtil.GetValues<TestColour>(), Is.EqualTo(expected).AsCollection);
+                var expected = new List<TestColour>
+                {
+                    TestColour.Red,
+                    TestColour.Green,
+                    TestColour.Blue,
+                    TestColour.Yellow
+                };
+                Assert.That(EnumUtil.GetValues<TestColour>(), Is.EqualTo(expected).AsCollection);
+            }
         }
 
-        [Test]
-        [TestCase("#FF0000", TestColour.Red)]
-        [TestCase("Red", TestColour.Red)]
-        [TestCase("#00FF00", TestColour.Green)]
-        [TestCase("Green", TestColour.Green)]
-        [TestCase("#0000FF", TestColour.Blue)]
-        [TestCase("Blue", TestColour.Blue)]
-        [TestCase("Yellow", TestColour.Yellow)]
-        public void ParseWithDescription_ShouldHandleParsableCases(string description, EnumUtilTests.TestColour expected)
-        {
-            Assert.That(EnumUtil.ParseWithDescription<TestColour>(description), Is.EqualTo(expected));
-        }
 
-        [Test]
-        public void ParseWithDescription_WhenCaseSensitiveParsing_ShouldThrowIfDescriptionNotExactMatch()
+        public class ParseWithDescriptionTests
         {
-            Assert.That(() => EnumUtil.ParseWithDescription<TestColour>("#ff0000", StringComparer.Ordinal),
-                        Throws.Exception);
-        }
+            [Test]
+            [TestCase("#FF0000", TestColour.Red)]
+            [TestCase("Red", TestColour.Red)]
+            [TestCase("#00FF00", TestColour.Green)]
+            [TestCase("Green", TestColour.Green)]
+            [TestCase("#0000FF", TestColour.Blue)]
+            [TestCase("Blue", TestColour.Blue)]
+            [TestCase("Yellow", TestColour.Yellow)]
+            public void ParseWithDescription_ShouldHandleParsableCases(string description, TestColour expected)
+            {
+                Assert.That(EnumUtil.ParseWithDescription<TestColour>(description), Is.EqualTo(expected));
+            }
 
-        [Test]
-        public void ParseWithDescription_ShouldThrowIfNotParseable()
-        {
-            Assert.That(() => EnumUtil.ParseWithDescription<TestColour>("#FFFF00"), Throws.Exception);
+            [Test]
+            public void ParseWithDescription_WhenCaseSensitiveParsing_ShouldThrowIfDescriptionNotExactMatch()
+            {
+                Assert.That(() => EnumUtil.ParseWithDescription<TestColour>("#ff0000", StringComparer.Ordinal),
+                            Throws.Exception);
+            }
+
+            [Test]
+            public void ParseWithDescription_ShouldThrowIfNotParseable()
+            {
+                Assert.That(() => EnumUtil.ParseWithDescription<TestColour>("#FFFF00"), Throws.Exception);
+            }
         }
     }
 }

--- a/test/Bashi.Core.Tests/Utils/EnumUtilTests.cs
+++ b/test/Bashi.Core.Tests/Utils/EnumUtilTests.cs
@@ -44,20 +44,20 @@ namespace Bashi.Core.Tests.Utils
             [TestCase("#0000FF", TestColour.Blue)]
             [TestCase("Blue", TestColour.Blue)]
             [TestCase("Yellow", TestColour.Yellow)]
-            public void ParseWithDescription_ShouldHandleParsableCases(string description, TestColour expected)
+            public void ShouldHandleParsableCases(string description, TestColour expected)
             {
                 Assert.That(EnumUtil.ParseWithDescription<TestColour>(description), Is.EqualTo(expected));
             }
 
             [Test]
-            public void ParseWithDescription_WhenCaseSensitiveParsing_ShouldThrowIfDescriptionNotExactMatch()
+            public void WhenCaseSensitiveParsing_ShouldThrowIfDescriptionNotExactMatch()
             {
                 Assert.That(() => EnumUtil.ParseWithDescription<TestColour>("#ff0000", StringComparer.Ordinal),
                             Throws.Exception);
             }
 
             [Test]
-            public void ParseWithDescription_ShouldThrowIfNotParseable()
+            public void ShouldThrowIfNotParseable()
             {
                 Assert.That(() => EnumUtil.ParseWithDescription<TestColour>("#FFFF00"), Throws.Exception);
             }


### PR DESCRIPTION
- Added `Enumerable.AsReadOnlyList()`
- Added `Enumerable.FirstRandom()`
- Added `TinyType.ToString()` override that points to underlying `TinyType.Value`.
- Removed implicit type cast of `TinyType<T>` to `T`.